### PR TITLE
Log from context

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -240,10 +240,10 @@ func Dial(ctx context.Context, nodeAddresses []string, conf BrokerConf) (*Broker
 			time.Sleep(conf.DialRetryWait)
 		}
 
-		err := broker.refreshMetadata(ctx, proto.MetadataV0)
-
-		if err == nil {
+		if err := broker.refreshMetadata(ctx, proto.MetadataV0); err == nil {
 			return broker, nil
+		} else if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return nil, errors.New("cannot connect")

--- a/error.go
+++ b/error.go
@@ -1,0 +1,18 @@
+/*
+
+Package kafka a provides high level client API for Apache Kafka.
+
+Use 'Broker' for node connection management, 'Producer' for sending messages,
+and 'Consumer' for fetching. All those structures implement Client, Consumer
+and Producer interface, that is also implemented in kafkatest package.
+
+*/
+package kafka
+
+import "context"
+
+// isCanceled returns true when the given error is
+// a context canceled or context deadline exceeded error.
+func isCanceled(err error) bool {
+	return err == context.Canceled || err == context.DeadlineExceeded
+}


### PR DESCRIPTION
Use logger from given context (if available, otherwise use default logger)

This PR extends #6