### PR TITLE
Considering connection dead on context timeout/cancellation

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -324,6 +324,10 @@ func (b *Broker) fetchMetadata(ctx context.Context, metadataVersion int16, topic
 			ClientID: b.conf.ClientID,
 			Topics:   topics,
 		})
+		if isCloseDeadConnectionNeeded(err) {
+			// Note: Mutex is already locked
+			b.closeDeadConnection(ctx, conn, false)
+		}
 		if isCanceled(err) {
 			return nil, err
 		} else if err != nil {


### PR DESCRIPTION
This PR intends to fix problems with a STOPed kafka.
Before the go context would expire without closing the `connection`. As a result the next attempt would use the same (failing) connection.

This PR tries to ensure that a connection is really closed when a context is either canceled or expired.